### PR TITLE
Feature: add type semantic-version-string

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -8,6 +8,7 @@
 	   #:semantic-version
 	   #:make-semantic-version
 	   #:version-string-valid-p
+           #:semantic-version-string
 	   #:version-major
 	   #:version-minor
 	   #:version-patch

--- a/semver.lisp
+++ b/semver.lisp
@@ -146,6 +146,9 @@
   (or (equalp string "latest")
       (not (null (ignore-errors (parse 'version string))))))
 
+(deftype semantic-version-string ()
+  '(and string (satisfies version-string-valid-p)))
+
 (defun read-version-from-string (string)
   "Parses a semantic version from a string"
   (when (typep string 'version)


### PR DESCRIPTION
The type `semantic-version-string` makes it possible to declare the type of a version string or validate a version string with `check-type`, etc.